### PR TITLE
Added undocumented SetComment method to LinkGrabberV2 and DownloadsV2

### DIFF
--- a/src/JDownloader/ApiConstants.cs
+++ b/src/JDownloader/ApiConstants.cs
@@ -1,4 +1,4 @@
-﻿namespace JDownloader
+namespace JDownloader
 {
     public static class ApiConstants
     {
@@ -108,6 +108,7 @@
             public const string RenamePackage = "renamePackage";
             public const string ResetLinks = "resetLinks";
             public const string ResumeLinks = "resumeLinks";
+            public const string SetComment = "setComment";
             public const string SetDownloadDirectory = "setDownloadDirectory";
             public const string SetDownloadPassword = "setDownloadPassword";
             public const string SetEnabled = "setEnabled";
@@ -198,6 +199,7 @@
             public const string RemoveLinks = "removeLinks";
             public const string RenameLink = "renameLink";
             public const string RenamePackage = "renamePackage";
+            public const string SetComment = "setComment";
             public const string SetDownloadDirectory = "setDownloadDirectory";
             public const string SetDownloadPassword = "setDownloadPassword";
             public const string SetEnabled = "setEnabled";

--- a/src/JDownloader/Namespace/IDownloadsV2.cs
+++ b/src/JDownloader/Namespace/IDownloadsV2.cs
@@ -1,4 +1,4 @@
-﻿using JDownloader.Model;
+using JDownloader.Model;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -136,6 +136,15 @@ namespace JDownloader.Namespace
         /// <param name="linkIds">The IDs of the links to be resumed.</param>
         /// <param name="packageIds">The IDs of the packages to be resumed.</param>
         Task ResumeLinks(long[] linkIds, long[] packageIds);
+
+        /// <summary>
+        /// Sets the comment for the specified links and packages.
+        /// </summary>
+        /// <param name="linkIds">The IDs of the links to set comment for.</param>
+        /// <param name="packageIds">The IDs of the packages to set comment for.</param>
+        /// <param name="setPackageChildren">Set comment for all children in package.</param>
+        /// <param name="comment">String to use for comment.</param>
+        Task SetComment(long[] linkIds, long[] packageIds, bool setPackageChildren, string comment);
 
         /// <summary>
         /// Sets the download directory for the specified packages.

--- a/src/JDownloader/Namespace/ILinkGrabberV2.cs
+++ b/src/JDownloader/Namespace/ILinkGrabberV2.cs
@@ -1,4 +1,4 @@
-﻿using JDownloader.Model;
+using JDownloader.Model;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -172,6 +172,15 @@ namespace JDownloader.Namespace
         /// <param name="packageId">The ID of the package to rename.</param>
         /// <param name="newName">The new name for the package.</param>
         Task RenamePackage(long packageId, string newName);
+
+        /// <summary>
+        /// Sets the comment for the specified links and packages.
+        /// </summary>
+        /// <param name="linkIds">The IDs of the links to set comment for.</param>
+        /// <param name="packageIds">The IDs of the packages to set comment for.</param>
+        /// <param name="setPackageChildren">Set comment for all children in package.</param>
+        /// <param name="comment">String to use for comment.</param>
+        Task SetComment(long[] linkIds, long[] packageIds, bool setPackageChildren, string comment);
 
         /// <summary>
         /// Sets the download directory for specified packages.

--- a/src/JDownloader/Namespace/Impl/DownloadsV2.cs
+++ b/src/JDownloader/Namespace/Impl/DownloadsV2.cs
@@ -1,4 +1,4 @@
-﻿using JDownloader.Model;
+using JDownloader.Model;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -65,6 +65,9 @@ namespace JDownloader.Namespace
 
         public Task ResumeLinks(long[] linkIds, long[] packageIds) =>
             PostRequestAsync(ApiConstants.DownloadsV2.ResumeLinks, new object[] { linkIds, packageIds });
+
+        public Task SetComment (long[] linkIds, long[] packageIds, bool setPackageChildren, string comment) =>
+            PostRequestAsync(ApiConstants.DownloadsV2.SetComment, new object[] { linkIds, packageIds, setPackageChildren, comment });
 
         public Task SetDownloadDirectory(string directory, long[] packageIds) =>
             PostRequestAsync(ApiConstants.DownloadsV2.SetDownloadDirectory, new object[] { directory, packageIds });

--- a/src/JDownloader/Namespace/Impl/LinkGrabberV2.cs
+++ b/src/JDownloader/Namespace/Impl/LinkGrabberV2.cs
@@ -1,4 +1,4 @@
-﻿using JDownloader.Model;
+using JDownloader.Model;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -81,6 +81,9 @@ namespace JDownloader.Namespace
 
         public Task RenamePackage(long packageId, string newName) =>
             PostRequestAsync(ApiConstants.LinkGrabberV2.RenamePackage, new object[] { packageId, newName });
+
+        public Task SetComment(long[] linkIds, long[] packageIds, bool setPackageChildren, string comment) =>
+            PostRequestAsync(ApiConstants.DownloadsV2.SetComment, new object[] { linkIds, packageIds, setPackageChildren, comment });
 
         public Task SetDownloadDirectory(long[] packageIds, string downloadPath) =>
             PostRequestAsync(ApiConstants.LinkGrabberV2.SetDownloadDirectory, new object[] { downloadPath, packageIds });


### PR DESCRIPTION
The Jdownloader api has a method for DownloadsV2 and LinkGrabberV2 that sets the comment for packages and files.
It works but It isn't in the api documentation and I only found out about it from the [support thread](https://board.jdownloader.org/showthread.php?t=90638) where it was first brought up.